### PR TITLE
python2-pip required in Amazon Linux 2

### DIFF
--- a/vars/Amazon-2.yml
+++ b/vars/Amazon-2.yml
@@ -6,6 +6,7 @@ supervisor_epel_package: >
   https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{supervisor_epel_release}}.noarch.rpm
 
 supervisor_packages:
+  - python2-pip
   - supervisor
 
 supervisor_prefix: /etc


### PR DESCRIPTION
Installing supervisor in Amazon Linux 2 currently fails, as `pip` is not available by default.